### PR TITLE
Fix boundary generation method

### DIFF
--- a/src/functions/sendEmail.ts
+++ b/src/functions/sendEmail.ts
@@ -59,7 +59,7 @@ export async function sendEmailFunction(gmailClient: gmail_v1.Gmail, params: ISe
         const { encodedContent: encodedSubject } = encodeEmailContent({ content: subject || '', type: EncodingType.Subject });
         const { isHtml } = detectHtml({ content: message });
 
-        let boundary = "----=_NextPart_" + Math.random().toString(36).substr(2, 9);
+        let boundary = "----=_NextPart_" + Math.random().toString(36).substring(2, 11);
         // Conditionally add senderName to the From header
         let mimeMessage = `From: ${senderName ? `"${senderName}" <${senderEmail}>` : senderEmail}\r\nTo: ${recipientEmail}\r\nSubject: ${encodedSubject}\r\n`;
 


### PR DESCRIPTION
## Summary
- fix boundary generation method in sendEmail.ts to use `substring`
- run TypeScript build

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68514df2fa288324b5b4b8e714825c58