### PR TITLE
Add typed service account parser result

### DIFF
--- a/src/GmailMailer.ts
+++ b/src/GmailMailer.ts
@@ -38,6 +38,7 @@ import {
   IInitializeClientParams,
   IInitializeClientResult,
   ISendEmailFunctionResponse,
+  IParseServiceAccountResult,
 } from './types';
 
 export class GmailMailer {
@@ -63,7 +64,7 @@ export class GmailMailer {
       }
 
       if (!gmailServiceAccount && gmailServiceAccountPath) {
-        const serviceAccountResult = await parseServiceAccountFile({ filePath: gmailServiceAccountPath });
+        const serviceAccountResult: IParseServiceAccountResult = await parseServiceAccountFile({ filePath: gmailServiceAccountPath });
         if (!serviceAccountResult.status || !serviceAccountResult.serviceAccount) {
           throw new Error(serviceAccountResult.message);
         }

--- a/src/__tests__/parseServiceAccountFile.test.ts
+++ b/src/__tests__/parseServiceAccountFile.test.ts
@@ -1,0 +1,35 @@
+import { promises as fsPromises } from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+import { parseServiceAccountFile } from '../utils/parseServiceAccountFile';
+import { IParseServiceAccountResult } from '../types';
+
+describe('parseServiceAccountFile', () => {
+  test('should parse a valid service account file', async () => {
+    const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'sa-'));
+    const filePath = path.join(tmpDir, 'service.json');
+    const serviceAccount = { private_key: 'key', client_email: 'client@example.com' };
+    await fsPromises.writeFile(filePath, JSON.stringify(serviceAccount), 'utf-8');
+
+    const result: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
+
+    expect(result.status).toBe(true);
+    expect(result.serviceAccount).toEqual(serviceAccount);
+    expect(typeof result.message).toBe('string');
+
+    await fsPromises.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  test('should handle missing file', async () => {
+    const tmpDir = await fsPromises.mkdtemp(path.join(os.tmpdir(), 'sa-'));
+    const filePath = path.join(tmpDir, 'missing.json');
+
+    const result: IParseServiceAccountResult = await parseServiceAccountFile({ filePath });
+
+    expect(result.status).toBe(false);
+    expect(result.serviceAccount).toBeUndefined();
+    expect(result.message).toContain('File not found');
+
+    await fsPromises.rm(tmpDir, { recursive: true, force: true });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,13 @@ export interface IGmailServiceAccount {
     client_email: string;
 }
 
+// Interface for the result of parsing a service account file
+export interface IParseServiceAccountResult {
+    status: boolean;
+    serviceAccount: IGmailServiceAccount | undefined;
+    message: string;
+}
+
 // Interface for parameters required to initialize the Gmail client
 export interface IInitializeClientParams {
     gmailServiceAccount?: IGmailServiceAccount;

--- a/src/utils/parseServiceAccountFile.ts
+++ b/src/utils/parseServiceAccountFile.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import { promises as fsPromises } from 'fs';
-import { IGmailServiceAccount } from '../types';
+import { IGmailServiceAccount, IParseServiceAccountResult } from '../types';
 
 /**
  * Checks if the provided error object has a `code` property.
@@ -16,10 +16,10 @@ function hasErrorCode(error: any): error is NodeJS.ErrnoException {
  * 
  * @param {Object} params - Parameters for parsing the service account file.
  * @param {string} params.filePath - The file path of the service account JSON file.
- * @returns {Promise<{status: boolean, serviceAccount: IGmailServiceAccount | undefined, message: string}>} 
+ * @returns {Promise<IParseServiceAccountResult>}
  *          The result of parsing the service account file, including status, the service account object (if successful), and a message.
  */
-export async function parseServiceAccountFile({ filePath }: { filePath: string }): Promise<{ status: boolean; serviceAccount: IGmailServiceAccount | undefined; message: string }> {
+export async function parseServiceAccountFile({ filePath }: { filePath: string }): Promise<IParseServiceAccountResult> {
     try {
         const absolutePath = path.resolve(filePath);
         const fileContents = await fsPromises.readFile(absolutePath, 'utf-8');


### PR DESCRIPTION
## Summary
- add `IParseServiceAccountResult` type
- return the typed result from `parseServiceAccountFile`
- use the new type in `GmailMailer`
- test service account parsing

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68578ff5bee08324bb3afb3cb59ebfb7