### PR TITLE
Add unit tests for utils and sendEmail

### DIFF
--- a/src/__tests__/detectHtml.test.ts
+++ b/src/__tests__/detectHtml.test.ts
@@ -1,0 +1,23 @@
+import { detectHtml } from '../utils/detectHtml';
+
+describe('detectHtml', () => {
+  test('detects html content', () => {
+    const res = detectHtml({ content: '<p>Hello</p>' });
+    expect(res.isHtml).toBe(true);
+    expect(res.message).toMatch('HTML content detected');
+  });
+
+  test('returns false for plain text', () => {
+    const res = detectHtml({ content: 'Hello' });
+    expect(res.isHtml).toBe(false);
+    expect(res.message).toMatch('No HTML content detected');
+  });
+
+  test('handles regex errors gracefully', () => {
+    const spy = jest.spyOn(RegExp.prototype, 'test').mockImplementation(() => { throw new Error('regex failure'); });
+    const res = detectHtml({ content: '<p>Error</p>' });
+    expect(res.isHtml).toBe(false);
+    expect(res.message).toMatch('regex failure');
+    spy.mockRestore();
+  });
+});

--- a/src/__tests__/encodeEmailContent.test.ts
+++ b/src/__tests__/encodeEmailContent.test.ts
@@ -1,0 +1,40 @@
+import { encodeEmailContent } from '../utils/encodeEmailContent';
+import { EncodingType } from '../types';
+
+describe('encodeEmailContent', () => {
+  test('encodes subject content', () => {
+    const res = encodeEmailContent({ content: 'Hello', type: EncodingType.Subject });
+    expect(res.isEncoded).toBe(true);
+    expect(res.encodedContent).toBe('=?utf-8?B?SGVsbG8=?=');
+  });
+
+  test('encodes MIME message as URL safe base64', () => {
+    const res = encodeEmailContent({ content: 'plain text', type: EncodingType.MimeMessage });
+    const expected = Buffer.from('plain text', 'utf-8').toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+    expect(res.isEncoded).toBe(true);
+    expect(res.encodedContent).toBe(expected);
+  });
+
+  test('encodes attachment when not already base64', () => {
+    const text = 'hello world';
+    const res = encodeEmailContent({ content: text, type: EncodingType.Attachment });
+    const expected = Buffer.from(text, 'utf-8').toString('base64');
+    expect(res.isEncoded).toBe(true);
+    expect(res.encodedContent).toBe(expected);
+  });
+
+  test('keeps attachment content when already base64', () => {
+    const base64 = Buffer.from('foo').toString('base64');
+    const res = encodeEmailContent({ content: base64, type: EncodingType.Attachment });
+    expect(res.isEncoded).toBe(true);
+    expect(res.encodedContent).toBe(base64);
+    expect(res.message).toMatch('already Base64 encoded');
+  });
+
+  test('returns error for invalid type', () => {
+    const res = encodeEmailContent({ content: 'test', type: 'bad-type' as any });
+    expect(res.isEncoded).toBe(false);
+    expect(res.encodedContent).toBe('test');
+    expect(res.message).toMatch('Invalid encoding type');
+  });
+});

--- a/src/__tests__/parseServiceAccountFile.test.ts
+++ b/src/__tests__/parseServiceAccountFile.test.ts
@@ -1,0 +1,48 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { parseServiceAccountFile } from '../utils/parseServiceAccountFile';
+
+describe('parseServiceAccountFile', () => {
+  const tempDir = path.join(__dirname, 'tmp');
+
+  beforeAll(() => {
+    if (!fs.existsSync(tempDir)) fs.mkdirSync(tempDir);
+  });
+
+  afterAll(() => {
+    if (fs.existsSync(tempDir)) fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test('loads valid service account file', async () => {
+    const filePath = path.join(tempDir, 'valid.json');
+    const content = { private_key: 'key', client_email: 'test@example.com' };
+    fs.writeFileSync(filePath, JSON.stringify(content));
+
+    const res = await parseServiceAccountFile({ filePath });
+    expect(res.status).toBe(true);
+    expect(res.serviceAccount).toEqual(content);
+  });
+
+  test('returns error when file missing', async () => {
+    const filePath = path.join(tempDir, 'missing.json');
+    const res = await parseServiceAccountFile({ filePath });
+    expect(res.status).toBe(false);
+    expect(res.message).toMatch('File not found');
+  });
+
+  test('returns error for invalid json', async () => {
+    const filePath = path.join(tempDir, 'invalid.json');
+    fs.writeFileSync(filePath, '{invalid json');
+    const res = await parseServiceAccountFile({ filePath });
+    expect(res.status).toBe(false);
+    expect(res.message).toMatch('invalid JSON');
+  });
+
+  test('returns error for missing fields', async () => {
+    const filePath = path.join(tempDir, 'missingFields.json');
+    fs.writeFileSync(filePath, JSON.stringify({ client_email: 'only@example.com' }));
+    const res = await parseServiceAccountFile({ filePath });
+    expect(res.status).toBe(false);
+    expect(res.message).toMatch("lacks required 'private_key' or 'client_email'");
+  });
+});

--- a/src/__tests__/sendEmailFunction.test.ts
+++ b/src/__tests__/sendEmailFunction.test.ts
@@ -1,0 +1,44 @@
+import { sendEmailFunction } from '../functions/sendEmail';
+import { encodeEmailContent } from '../utils/encodeEmailContent';
+
+jest.mock('../utils/encodeEmailContent');
+
+describe('sendEmailFunction', () => {
+  const mockSend = jest.fn();
+  const gmailClient: any = { users: { messages: { send: mockSend } } };
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  test('sends email successfully', async () => {
+    mockSend.mockResolvedValue({ status: 200, statusText: 'OK' });
+    (encodeEmailContent as jest.Mock).mockImplementation(({ content }) => ({ isEncoded: true, encodedContent: Buffer.from(content).toString('base64'), message: '' }));
+
+    const res = await sendEmailFunction(gmailClient, { senderEmail: 'sender@example.com', senderName: 'Sender', recipientEmail: 'to@example.com', subject: 'Hi', message: 'hello' });
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(res.sent).toBe(true);
+    expect(res.message).toMatch('Email successfully sent to to@example.com');
+  });
+
+  test('handles gmail api failure', async () => {
+    mockSend.mockRejectedValue(new Error('api fail'));
+    (encodeEmailContent as jest.Mock).mockReturnValue({ isEncoded: true, encodedContent: 'abc', message: '' });
+
+    const res = await sendEmailFunction(gmailClient, { senderEmail: 'sender@example.com', recipientEmail: 'to@example.com', message: 'body' });
+    expect(res.sent).toBe(false);
+    expect(res.message).toMatch('api fail');
+  });
+
+  test('handles encoding failure', async () => {
+    mockSend.mockResolvedValue({ status: 200 });
+    (encodeEmailContent as jest.Mock).mockReturnValue({ isEncoded: false, encodedContent: '', message: 'fail' });
+
+    const res = await sendEmailFunction(gmailClient, { senderEmail: 'sender@example.com', recipientEmail: 'to@example.com', message: 'body' });
+
+    expect(mockSend).not.toHaveBeenCalled();
+    expect(res.sent).toBe(false);
+    expect(res.message).toMatch('Failed to encode MIME message');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for `encodeEmailContent`
- test html detection
- cover service account parsing
- mock Gmail API and test `sendEmailFunction`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68578ff966d483249c9ee04b8b820930